### PR TITLE
added max-width style to html tag

### DIFF
--- a/style.css
+++ b/style.css
@@ -10,6 +10,12 @@ Version:        1.0
 
 @import url("../p2/style.css");
 
+/* max-width on html, excessive width causing rendering issues */
+html {
+	max-width: 1171px;
+	margin: 0 auto;
+}
+
 /* Mobile layout first */
 
 body {


### PR DESCRIPTION
I added a max-width and auto-margins to the <html> tag. Found excessive width causes problems with the layout (especially with the gravatar). Tested with Chrome, Firefox, Safari (OS X), and Chrome, Safari (iOS).
