### PR TITLE
removing P2 call to iPhone Stylesheet without the need to tweak parent c...

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -86,4 +86,11 @@ function p2_responsive_comments( $comment, $args ) {
 	<?php
 }
 
+// remove iPhone styles from original P2
+// explained here: http://wpguru.co.uk/2013/10/how-to-override-a-parent-function-from-your-child-theme/
+function p2_responsive_remove_iPhone () {
+	remove_action( 'wp_enqueue_scripts', 'p2_iphone_style', 1000 );
+}
+add_action( 'after_setup_theme', 'p2_responsive_remove_iPhone' );
+
 ?>


### PR DESCRIPTION
HI Jono,

nice work on P2 Responsive! I've added a fix which allows for the original P2 call to the iPhone styles to be overwritten. That way users no longer need to hack their original P2 functions file. I've written about how to do this here: http://wpguru.co.uk/2013/10/how-to-override-a-parent-function-from-your-child-theme/

Any questions, let me know.
